### PR TITLE
feat: add soupport for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   ],
   "require": {
     "php": ">=7.2",
-    "illuminate/events": "^8.0|^9.0|^10.0"
+    "illuminate/events": "^8.0|^9.0|^10.0|^11.0"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
如標題所述，加上對 `illuminate/events` 11 的支援。

在 local 測試過應該沒問題